### PR TITLE
メッセージ送信機能の修正

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,7 @@ gem 'font-awesome-rails'
 gem 'devise'
 gem 'pry-rails'
 gem 'carrierwave'
+gem 'rmagick'
 
 group :test do
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -159,6 +159,7 @@ GEM
     rdoc (4.3.0)
     responders (2.3.0)
       railties (>= 4.2.0, < 5.1)
+    rmagick (2.16.0)
     rspec-core (3.6.0)
       rspec-support (~> 3.6.0)
     rspec-expectations (3.6.0)
@@ -240,6 +241,7 @@ DEPENDENCIES
   pry-rails
   rails (~> 5.0.0, >= 5.0.0.1)
   rails-controller-testing
+  rmagick
   rspec-rails
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)

--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -1,34 +1,46 @@
 $(function() {
   function buildHTML(message) {
-    var htmlName = $('<p class="posted-user-name">').append(message.name);
-    var htmlTime = $('<p class="created-at">').append(message.created_at);
-    var htmlText = $('<p class="user-message">').append(message.text);
-    var html = [htmlName, htmlTime, htmlText];
-    return html;
+    var addImage = (message.image !== null) ? `<img class = "image_size", src="${message.image}">` : ''
+    var html = `
+      <p class = "posted-user-name">
+        ${message.name}
+      </p>
+        <p class = "created-at">
+      ${message.created_at}
+        </p>
+      <p class = "user-message">
+        ${message.text}
+      </p>
+      <p class = "user-image">
+        ${addImage}
+      </p>`
+      return html
   }
-
   $('.type-message--send').on('click', function(e) {
     e.preventDefault();
     var textField = $('.type-message');
     var message = textField.val();
+    var formdata = new FormData($("#form_id").get(0));
+    // 復習で残す
+    // console.log("===message===");
+    // console.log(message);
+    // console.log("===item===");
+    // for(item of formdata) console.log(item);
+    // console.log("===image===");
+    // console.log(formdata.get("message[image]"));
     $.ajax({
       type: 'POST',
       url: './messages',
-      data: {
-        message: {
-          text: message
-        }
-      },
+      data: formdata,
+      processData: false,
+      contentType: false,
       dataType: 'json'
     })
     .done(function(data) {
       var html = buildHTML(data);
-      for(var i = 0; i < html.length; i++) {
-      $('.chat__content-message').append(html);
-    }
+      $(".chat__content-message").append(html);
       textField.val('');
-
-    })
+      })
     .fail(function() {
       alert("メッセージを入力してください");
     });

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -45,13 +45,15 @@
       font-size: 12px;
       line-height: 16px;
     }
-    p.user-message{
+    p.user-message {
       padding: 10px 0 40px 0px;
       font-size: 14px;
       color: #434a54;
-
     }
-
+    .image_size {
+        height: 100px;
+        width: 100px;
+    }
   }
   &__send-message {
     background-color: gray;

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -27,7 +27,7 @@ def find_group
 end
 
 def message_params
-  params.require(:message).permit(:text).merge(group_id: params[:group_id])
+  params.require(:message).permit(:text, :image).merge(group_id: params[:group_id])
 end
 
 end

--- a/app/views/messages/_message.html.haml
+++ b/app/views/messages/_message.html.haml
@@ -4,3 +4,6 @@
   = message.created_at
 %p.user-message
   = message.text
+- if message.image.url
+  %p.user-image
+    = image_tag message.image, class: "image_size"

--- a/app/views/messages/create.json.jbuilder
+++ b/app/views/messages/create.json.jbuilder
@@ -1,3 +1,4 @@
 json.name       @message.user.name
 json.created_at @message.created_at
 json.text       @message.text
+json.image      @message.image.url

--- a/app/views/messages/index.html.haml
+++ b/app/views/messages/index.html.haml
@@ -22,7 +22,7 @@
     = render partial: 'message', collection: @messages
 
   .chat__send-message
-    = form_for [@group, @message] do |f|
+    = form_for [@group, @message], html: {id: :form_id }  do |f|
       = f.text_field :text, class: "type-message", placeholder: "Type a message"
       = f.label :image do
         = f.file_field :image, class: "type-message--image", style: "display:none;"


### PR DESCRIPTION
# WHAT
画像を非同期で送信できるようにする。
(S3はまだ使っていません。)
# WHY
画像送信を円滑に行うため。


![mov](https://cloud.githubusercontent.com/assets/28098037/26521115/8401fdd0-431b-11e7-907b-c6815971a0c5.gif)
